### PR TITLE
fix typo in document.getElementById() call

### DIFF
--- a/src/midi/midi2.js
+++ b/src/midi/midi2.js
@@ -10,7 +10,7 @@ for (var input of midiAccess.inputs.values())
 
 function getMIDIMessage(midiMessage) {
 console.log(midiMessage.data[1]);
-document.GetElementById('midiValue').innerHTML = midiMessage.data[1];
+document.getElementById('midiValue').innerHTML = midiMessage.data[1];
 }
 
 function onFailure() {


### PR DESCRIPTION
getElementById() was spelled as GetElementById() which resulted in the non-working code copied to clipboard from the copy to clipboard button.